### PR TITLE
Allow script to terminate early if vagrant returns errors

### DIFF
--- a/vagrant/getports.sh
+++ b/vagrant/getports.sh
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/bin/bash -e
 
 if (( "$#" != 1 ))
 then


### PR DESCRIPTION
This happens when VMs are hanging or powered off for example.