### PR TITLE
Update ubuntu to version 20.04 in Dockerfile and travis.yml

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -2,7 +2,7 @@ os:
   - linux
 
 dist:
-  - trusty
+  - bionic
 
 sudo:
   - required
@@ -12,9 +12,9 @@ services:
 
 before_script:
   - sudo apt-get install -y linux-headers-$(uname -r)
-  - docker pull ubuntu:disco
-  - docker build --build-arg https_proxy=${https_proxy} -t test-disco .
-  - docker run -it -d --privileged -v /usr/src:/usr/src -v /lib/modules:/lib/modules -v /sys/devices/system/node:/sys/devices/system/node --name test-nff-go test-disco /bin/bash
+  - docker pull ubuntu:focal
+  - docker build --build-arg https_proxy=${https_proxy} -t test-focal .
+  - docker run -it -d --privileged -v /usr/src:/usr/src -v /lib/modules:/lib/modules -v /sys/devices/system/node:/sys/devices/system/node --name test-nff-go test-focal /bin/bash
 
 script:
   - docker exec -i test-nff-go go mod download

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,6 +1,7 @@
-FROM ubuntu:disco
+FROM ubuntu:focal
 
 ARG MAKEFLAGS=-j2
+ARG DEBIAN_FRONTEND=noninteractive
 
 ENV GOROOT /opt/go
 ENV PATH ${GOROOT}/bin:${GOPATH}/bin:${PATH}
@@ -8,12 +9,13 @@ ENV NFF_GO /nff-go
 
 RUN apt-get -q update && apt-get -q -y install \
     make \
+    build-essential \
     git \
     curl \
     wget \
     libpcap-dev \
     libelf-dev \
-    hugepages  \
+    libhugetlbfs-bin \
     libnuma-dev \
     libhyperscan-dev \
     liblua5.3-dev \


### PR DESCRIPTION
Building docker using "ubuntu:disco" as base image currently fails, now that 19.04 has reached end-of-life.

```
E: The repository 'http://security.ubuntu.com/ubuntu disco-security Release' does not have a Release file.
E: The repository 'http://archive.ubuntu.com/ubuntu disco Release' does not have a Release file.
E: The repository 'http://archive.ubuntu.com/ubuntu disco-updates Release' does not have a Release file.
E: The repository 'http://archive.ubuntu.com/ubuntu disco-backports Release' does not have a Release file.
The command '/bin/sh -c apt-get -q update && apt-get -q -y install     make     git     curl     wget     libpcap-dev     libelf-dev     hugepages      libnuma-dev     libhyperscan-dev     liblua5.3-dev     libmnl-dev     libibverbs-dev' returned a non-zero code: 100
The command "docker build --build-arg https_proxy=${https_proxy} -t test-disco ." failed and exited with 100 during .
```
This PR suggests a way to fix this by using Ubuntu focal (20.04) instead, as it's the latest LTS release. Another option could be to use Ubuntu eoan (19.10) but the issue would come back in a few months.

In Ubuntu 20.04, the hugepages package is replaced by libhugetlbfs-bin it seems.
```
E: Unable to locate package hugepages
The command '/bin/sh -c apt-get -q update && apt-get -q -y install     make     git     curl     wget     libpcap-dev     libelf-dev     hugepages     libnuma-dev     libhyperscan-dev     liblua5.3-dev     libmnl-dev     libibverbs-dev' returned a non-zero code: 100
```
https://launchpad.net/ubuntu/focal/+package/libhugetlbfs-bin
https://launchpad.net/ubuntu/focal/+package/hugepages